### PR TITLE
Added type to signature of _patch

### DIFF
--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -152,7 +152,7 @@ class EditAction extends BaseAction
      * @param mixed $id Record id
      * @return \Cake\Http\Response|void
      */
-    protected function _patch($id = null)
+    protected function _patch(?string $id = null)
     {
         return $this->_put($id);
     }

--- a/src/Action/EditAction.php
+++ b/src/Action/EditAction.php
@@ -149,7 +149,7 @@ class EditAction extends BaseAction
      *
      * Thin proxy for _put
      *
-     * @param mixed $id Record id
+     * @param string|null $id Record id
      * @return \Cake\Http\Response|void
      */
     protected function _patch(?string $id = null)


### PR DESCRIPTION
Hi!

Currently _patch is mixed, so when an int is passed it will cause a type error, because _put is strongly typed.

Cheers,

Frank